### PR TITLE
fix: switch to amazoncorretto:19-alpine-jdk to support Minecraft 1.19.2+

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 # Environment Variables
+MC_VERSION=1.19.2

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ logs/
 # IntelliJ
 .idea
 *.iml
+
+mods
+plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM amazoncorretto:19-alpine-jdk AS base
 ENV JAVA_MAX_RAM 4G
 ENV JAVA_MIN_RAM 2G
+ARG MC_VERSION=latest
 
 # metadata
-LABEL maintainer="UpcraftLP <https://github.com/UpcraftLP>"
+LABEL maintainer="il-kimo <https://github.com/il-kimo>"
 
 #set working directory
 WORKDIR /app
@@ -18,8 +19,8 @@ RUN apk add --no-cache jq
 # get latest fabric installer
 RUN curl $(curl https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].url') --output fabric-installer.jar
 
-# install fabric
-RUN java -jar fabric-installer.jar server -downloadMinecraft
+# install fabric 
+RUN java -jar fabric-installer.jar server -downloadMinecraft -mcversion $MC_VERSION
 
 # create eula.txt
 RUN echo eula=true >> eula.txt
@@ -34,6 +35,9 @@ COPY --from=build /app/ .
 
 # copy configuration files
 COPY server.properties .
+
+# copy mods
+COPY mods /app/mods
 
 # main connection port
 EXPOSE 25565

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk16:jdk-16.0.1_9-alpine AS base
+FROM amazoncorretto:19-alpine-jdk AS base
 ENV JAVA_MAX_RAM 4G
 ENV JAVA_MIN_RAM 2G
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Target for creating .env file from .env.example
+env_file:
+	if [ ! -f .env ]; then \
+		cp .env.example .env; \
+	fi
+	mkdir -p {mods,plugins}
+
+# Target to launch docker-compose
+server: env_file
+	docker compose --env-file .env up --build
+
+# Default target
+all: server
+
+.PHONY: env_file up all
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 docker-fabric-server
+
+# Set server version
+After launching $ make env_file, you can modify the version of the minecraft server to generate by editing the MC_VERSION variable in the generated .env file.
+
+# Build
+```/shell
+make server
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: '3.8'
 
 services:
   fabric:
-    build: .
+    build:
+      context: .
+      args:
+        MC_VERSION: "${MC_VERSION-latest}"
     ports:
       - '25565:25565'
+


### PR DESCRIPTION
Yo!

I updated the Dockerfile base image with one that had the correct JDK, let me know if it seems right to you.

P.S.
I don't know if there are lighter/better options to fix it, in case I should be interested in knowing what is better and why!